### PR TITLE
Update vagrant installation method

### DIFF
--- a/vagrant/vagrant-and-packer.md
+++ b/vagrant/vagrant-and-packer.md
@@ -1,11 +1,11 @@
 # Installing Vagrant/Packer on Ubuntu/Debian
 ### Add the HashiCorp GPG key.
 ```bash
-curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
 ```
 ### Add the official HashiCorp Linux repository.
 ```bash
-sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
 ```
 ### Update and install.
 ```bash


### PR DESCRIPTION
Fix the `apt-key` deprecation error