### PR TITLE
edit hosts.yml

### DIFF
--- a/ansible/nginx-practices/inventory/hosts.yml
+++ b/ansible/nginx-practices/inventory/hosts.yml
@@ -1,13 +1,13 @@
 all:
     children:
-        web-servers:
+        webservers:
             hosts:
                 web1.ansible.mecan.ir:
                     ansible_host: 192.168.56.101
                     ansible_user: root
                     ansible_port: 8090
 
-        db-servers:
+        dbservers:
             hosts:
                 db1.ansible.mecan.ir:
                     ansible_host: 192.168.56.111


### PR DESCRIPTION
An Ansible variable name can only include letters, numbers, and underscores.