### PR TITLE
Refactored GitLab Nginx configuration: Updated compose.yml

### DIFF
--- a/gitlab/repository-server/gitlab/compose.yml
+++ b/gitlab/repository-server/gitlab/compose.yml
@@ -40,9 +40,6 @@ services:
         nginx['listen_port'] = 80
         nginx['listen_https'] = false
         nginx['proxy_cache'] = 'gitlab'
-        nginx['http2_enabled'] = true
-        nginx['listen_port'] = 80
-        nginx['listen_https'] = false
         nginx['http2_enabled'] = false
         nginx['proxy_set_headers'] = {
           "Host" => "$$http_host",


### PR DESCRIPTION
Nginx Configuration:
There were repeated entries for `nginx['listen_port']` and `nginx['listen_https']` in the GitLab compose file.
