### PR TITLE
Update Vagrantfile to Use Ubuntu 24.04

### DIFF
--- a/vagrant/vbox-environment-simple/Vagrantfile
+++ b/vagrant/vbox-environment-simple/Vagrantfile
@@ -1,4 +1,4 @@
-IMAGE_ubuntu_2204   = "bento/ubuntu-22.04"
+IMAGE_ubuntu_2404   = "bento/ubuntu-24.04"
 IMAGE_Debian_12     = "bento/debian-12"
 
 Vagrant.configure("2") do |config|


### PR DESCRIPTION
- Description
When using the command as described in the [Linux section of the repository](https://github.com/AhmadRafiee/DevOps_Certification/tree/main/linux#update-and-install), the output indicates that Ubuntu 24.04 is downloaded. However, the current Vagrantfile is configured to use Ubuntu 22.04. This discrepancy can lead to the unnecessary download of the 22.04 version, causing inefficiencies. To resolve this, the Vagrantfile should be updated to use Ubuntu 24.04, or alternatively, the command in the Linux section should be adjusted to ensure that Ubuntu 22.04 is downloaded.

- Changes Made
Updated the Vagrantfile to use Ubuntu 24.04 instead of 22.04.

