### PR TITLE
Fix docker blob var name

### DIFF
--- a/gitlab/repository-server/nexus/nexus-setup-with-api.sh
+++ b/gitlab/repository-server/nexus/nexus-setup-with-api.sh
@@ -221,7 +221,7 @@ curl -k -X 'POST' \
   "name": "hub",
   "online": true,
   "storage": {
-    "blobStoreName": "'${BLOB_STORE_NAME}'",
+    "blobStoreName": "'${DOCKER_BLOB_STORE_NAME}'",
     "strictContentTypeValidation": true
   },
   "cleanup": {


### PR DESCRIPTION
This pull request includes a small but important change to the `gitlab/repository-server/nexus/nexus-setup-with-api.sh` file. The change updates the `blobStoreName` property to use a different variable, ensuring the correct blob store is referenced.

* [`gitlab/repository-server/nexus/nexus-setup-with-api.sh`](diffhunk://#diff-0d2cb1db146fb6c4dec3383ea546bfc4dc492c75a6737855664c4fc554275fb8L224-R224): Changed `blobStoreName` from `'${BLOB_STORE_NAME}'` to `'${DOCKER_BLOB_STORE_NAME}'`.